### PR TITLE
Generate workspace name from branch name in PR

### DIFF
--- a/.github/workflows/data-parse-workspace.yml
+++ b/.github/workflows/data-parse-workspace.yml
@@ -31,7 +31,7 @@ jobs:
       - id: workspace_name
         name: Generate
         run: |
-          # Use a the source branch name if this is a pull request
+          # Use the source branch name if this is a pull request
           if [ -z "${GITHUB_HEAD_REF}" ]; then
             branch=${GITHUB_REF#refs/heads/}
           else

--- a/.github/workflows/data-parse-workspace.yml
+++ b/.github/workflows/data-parse-workspace.yml
@@ -31,7 +31,12 @@ jobs:
       - id: workspace_name
         name: Generate
         run: |
-          branch=${GITHUB_REF#refs/heads/}
+          # Use a the source branch name if this is a pull request
+          if [ -z "${GITHUB_HEAD_REF}" ]; then
+            branch=${GITHUB_REF#refs/heads/}
+          else
+            branch=${GITHUB_HEAD_REF}
+          fi
           echo "BRANCH: ${branch}"
 
           if [ "${branch}" == "main" ]; then


### PR DESCRIPTION
# Purpose

Generate a workspace name from branch name when [Data - Parse] Terraform Workspace Name is called by a PR.

## Approach

Use GITHUB_HEAD_REF as the branch name if it is set. If it is unset, continue to use GITHUB_REF.

## Learning

n/a

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
