### PR TITLE
Require PAGERDUTY_TOKEN for TF Plan And Build

### DIFF
--- a/.github/workflows/build-infrastructure-terraform.yml
+++ b/.github/workflows/build-infrastructure-terraform.yml
@@ -69,6 +69,8 @@ on:
         required: true
       AWS_SECRET_ACCESS_KEY_ACTIONS:
         required: true
+      PAGERDUTY_TOKEN:
+        required: true
 
 jobs:
   terraform_plan_and_apply:
@@ -111,6 +113,7 @@ jobs:
           TF_VAR_aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
           TF_VAR_aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
           TF_VAR_github_token: ${{ secrets.GITHUB_TOKEN }}
+          TF_VAR_pagerduty_token: ${{ secrets.PAGERDUTY_TOKEN }}
         run: |
           terraform workspace show
           terraform plan -input=false -parallelism=30 ${{ inputs.terraform_variables }}
@@ -132,6 +135,7 @@ jobs:
           TF_VAR_aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
           TF_VAR_aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
           TF_VAR_github_token: ${{ secrets.GITHUB_TOKEN }}
+          TF_VAR_pagerduty_token: ${{ secrets.PAGERDUTY_TOKEN }}
         run: |
           terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30 ${{ inputs.terraform_variables }}
         working-directory: ${{ inputs.terraform_directory }}


### PR DESCRIPTION
# Purpose

Require a PAGERDUTY_TOKEN GH Actions Secret for Terraform Plan and Build job and export it as a TF_VAR_pagerduty_token environment variable when running terraform commands.

Fixes LPAL-954

## Approach

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
