### PR TITLE
LPAL-1019 Add lock timeouts to TF init and plan

### DIFF
--- a/.github/workflows/build-infrastructure-terraform.yml
+++ b/.github/workflows/build-infrastructure-terraform.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Terraform Init
         run: |
-          terraform init -input=false
+          terraform init -lock-timeout=300s -input=false
         working-directory: ${{ inputs.terraform_directory }}
 
       - name: Terraform List Workspaces
@@ -143,7 +143,7 @@ jobs:
           TF_VAR_circleci_token: ${{ secrets.CIRCLECI_TOKEN }}
         run: |
           terraform workspace show
-          terraform plan -input=false -parallelism=30 ${{ inputs.terraform_variables }}
+          terraform plan -lock-timeout=300s -input=false -parallelism=30 ${{ inputs.terraform_variables }}
         working-directory: ${{ inputs.terraform_directory }}
 
       - name: Register ephemeral workspace


### PR DESCRIPTION
# Purpose

Add lockout timeout to prevent parallel pipeline runs from causing each other to fail

Fixes LPAL-1019

## Approach

Add -lock-timeout to init and plan commands

## Learning


## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
