### PR TITLE
LPAL-1036 Use GITHIB_OUTPUT environment variable

### DIFF
--- a/.github/workflows/build-infrastructure-terraform.yml
+++ b/.github/workflows/build-infrastructure-terraform.yml
@@ -180,5 +180,5 @@ jobs:
         env:
           TF_WORKSPACE: ${{ inputs.terraform_workspace }}
         run: |
-          echo ::set-output name=terraform_output_as_json::$(terraform output -json)
+          echo "terraform_output_as_json=$(terraform output -json)" >> $GITHUB_OUTPUT
         working-directory: ${{ inputs.terraform_directory }}

--- a/.github/workflows/data-parse-add-index.yml
+++ b/.github/workflows/data-parse-add-index.yml
@@ -46,4 +46,4 @@ jobs:
           $(jq -c '.[]' <<< ${{ inputs.original_list }})
           EOT
 
-          echo "::set-output name=indexed::${index_added}"
+          echo "indexed=${index_added}" >> $GITHUB_OUTPUT

--- a/.github/workflows/data-parse-branch-name.yml
+++ b/.github/workflows/data-parse-branch-name.yml
@@ -65,9 +65,9 @@ jobs:
           echo "PARSED BRANCH: ${parsed_branch}"
           echo "ALPHANUMERIC BRANCH: ${alphanumeric_branch}"
 
-          echo "::set-output name=raw_branch::${raw_branch}"
-          echo "::set-output name=parsed_branch::${parsed_branch}"
-          echo "::set-output name=alphanumeric_branch::${alphanumeric_branch}"
+          echo "raw_branch=${raw_branch}" >> $GITHUB_OUTPUT
+          echo "parsed_branch=${parsed_branch}" >> $GITHUB_OUTPUT
+          echo "alphanumeric_branch=${alphanumeric_branch}" >> $GITHUB_OUTPUT
 
       - name: Push to GITHUB_ENV
         if: inputs.push_to_github_env

--- a/.github/workflows/data-parse-workspace.yml
+++ b/.github/workflows/data-parse-workspace.yml
@@ -50,5 +50,5 @@ jobs:
             workspace_name=$(echo ${workspace_name} | tr '[:upper:]' '[:lower:]')
           fi
 
-          echo ::set-output name=workspace_name::${workspace_name}
+          echo "workspace_name=${workspace_name}" >> $GITHUB_OUTPUT
           echo "WORKSPACE: ${workspace_name}"


### PR DESCRIPTION
# Purpose

Remove use of deprecated set-output command in Github Actions.

Fixes LPAL-1036

## Approach

Replaces use of command with appending key:value pairs to the GITHUB_OUTPUT env var.

## Learning

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
