### PR TITLE
LPAL-1333 allow overwriting of artifact during upload (prevents 409 errors)

### DIFF
--- a/.github/workflows/build-infrastructure-terraform.yml
+++ b/.github/workflows/build-infrastructure-terraform.yml
@@ -220,6 +220,7 @@ jobs:
         with:
           name: terraform-artifact
           path: ${{ inputs.artifact_directory }}
+          overwrite: true
 
 
       - name: Terraform Outputs


### PR DESCRIPTION
# Purpose

_When uploading an artifiact, with version 4 of upload-artifact it is necessary to explicitly allow overwrite otherwise if you upload the same artifact more than once you will get a 409 error, thus blocking pipelines._

## Approach

_Add the overwrite flag set to true._

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
